### PR TITLE
FIXED #7 bug with sending session when getting account

### DIFF
--- a/src/Net.TMDb/ServiceClient.cs
+++ b/src/Net.TMDb/ServiceClient.cs
@@ -1061,7 +1061,8 @@ namespace System.Net.TMDb
 
 			public async Task<Account> GetAccountAsync(string session, CancellationToken cancellationToken)
 			{
-				var response = await client.GetAsync("account", null, cancellationToken).ConfigureAwait(false);
+                var parameters = new Dictionary<string, object> { { "session_id", session }};
+                var response = await client.GetAsync("account", parameters, cancellationToken).ConfigureAwait(false);
 				return await Deserialize<Account>(response);
 			}
 


### PR DESCRIPTION
Created parameters Dictionary<string, object> and include session_id. Parameters pass on in GetAccountAsync